### PR TITLE
External viewer support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -272,6 +272,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3dca9240753cf90908d7e4aac30f630662b02aebaa1b58a3cadabdb23385b58b"
 
 [[package]]
+name = "errno"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "eyre"
 version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -280,6 +290,12 @@ dependencies = [
  "indenter",
  "once_cell",
 ]
+
+[[package]]
+name = "fastrand"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fc0510504f03c51ada170672ac806f1f105a88aa97a5281117e1ddc3368e51a"
 
 [[package]]
 name = "form_urlencoded"
@@ -318,6 +334,7 @@ dependencies = [
  "crossterm",
  "git2",
  "ratatui",
+ "tempfile",
 ]
 
 [[package]]
@@ -539,6 +556,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
+
+[[package]]
 name = "litemap"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -718,6 +741,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
+name = "rustix"
+version = "0.38.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -870,6 +906,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85b77fafb263dd9d05cbeac119526425676db3784113aa9295c88498cbf8bff1"
+dependencies = [
+ "cfg-if",
+ "fastrand",
+ "rustix",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,4 @@ color-eyre = "0.6.3"
 crossterm = "0.27.0"
 git2 = { version = "0.19.0", default-features = false }
 ratatui = "0.26.3"
+tempfile = "3.10.1"

--- a/src/app.rs
+++ b/src/app.rs
@@ -30,7 +30,7 @@ use crate::{
         blob_pager::BlobPager, external_editor::ExternalEditor, navigation::NavigationAction,
         refs_page::RefsPage, tree_page::TreePage,
     },
-    errors::GitBrowserError,
+    errors::{ErrorKind, GitBrowserError},
 };
 
 pub enum AppMode {
@@ -357,7 +357,9 @@ impl<'repo> App<'repo> {
 
                     let blob = match object.into_blob() {
                         Ok(blob) => blob,
-                        Err(_) => panic!("peeling blob"),
+                        Err(_) => {
+                            return Err(GitBrowserError::Error(ErrorKind::BlobReferenceError));
+                        }
                     };
 
                     Some(ExternalEditor::new(&blob, &name, &self.editor))

--- a/src/app.rs
+++ b/src/app.rs
@@ -33,6 +33,7 @@ use crate::{
     errors::{ErrorKind, GitBrowserError},
 };
 
+#[derive(Debug)]
 pub enum AppMode {
     BrowseRefs,
     BrowseTrees,
@@ -373,7 +374,10 @@ impl<'repo> App<'repo> {
         };
         self.mode_history.push(AppMode::ExternalEditor);
         if let Some(external_editor) = &mut self.external_editor {
-            external_editor.display()?;
+            if let Some(e) = external_editor.display().err() {
+                self.back();
+                return Err(e);
+            };
         }
         // We need to go back to the previous mode after the blocking editor display
         self.back();

--- a/src/app.rs
+++ b/src/app.rs
@@ -333,6 +333,8 @@ impl<'repo> App<'repo> {
                 if let Some(external_editor) = &mut self.external_editor {
                     external_editor.display();
                 }
+                // We need to go back to the previous mode after the blocking editor display
+                self.back();
             }
         }
     }

--- a/src/app.rs
+++ b/src/app.rs
@@ -27,9 +27,8 @@ mod tree_page;
 
 use crate::{
     app::{
-        blob_pager::BlobPager, external_editor::ExternalEditor,
-        navigation::NavigationAction, refs_page::RefsPage,
-        tree_page::TreePage,
+        blob_pager::BlobPager, external_editor::ExternalEditor, navigation::NavigationAction,
+        refs_page::RefsPage, tree_page::TreePage,
     },
     errors::GitBrowserError,
 };
@@ -328,7 +327,8 @@ impl<'repo> App<'repo> {
     pub fn view_blob(&mut self) {
         if matches!(self.mode(), AppMode::ViewBlob) {
             if let Some(pager) = &self.blob_pager {
-                self.external_editor = Some(ExternalEditor::new(&pager.blob, &pager.name, "emacsclient"));
+                self.external_editor =
+                    Some(ExternalEditor::new(&pager.blob, &pager.name, "emacsclient"));
                 self.mode_history.push(AppMode::ExternalEditor);
                 if let Some(external_editor) = &mut self.external_editor {
                     external_editor.display();

--- a/src/app.rs
+++ b/src/app.rs
@@ -373,7 +373,7 @@ impl<'repo> App<'repo> {
         };
         self.mode_history.push(AppMode::ExternalEditor);
         if let Some(external_editor) = &mut self.external_editor {
-            external_editor.display();
+            external_editor.display()?;
         }
         // We need to go back to the previous mode after the blocking editor display
         self.back();

--- a/src/app.rs
+++ b/src/app.rs
@@ -52,10 +52,11 @@ pub struct App<'repo> {
     mode_history: Vec<AppMode>,
     height: u16,
     active_error: Option<GitBrowserError>,
+    editor: String,
 }
 
 impl<'repo> App<'repo> {
-    pub fn new(repo: &'repo Repository, commit_object: Option<Object<'repo>>) -> App<'repo> {
+    pub fn new(repo: &'repo Repository, commit_object: Option<Object<'repo>>, editor: String) -> App<'repo> {
         let mut new = App {
             search_input: String::new(),
             repo,
@@ -67,6 +68,7 @@ impl<'repo> App<'repo> {
             mode_history: vec![AppMode::BrowseRefs],
             height: 0,
             active_error: None,
+            editor,
         };
         if let Some(object) = &commit_object {
             match object.peel_to_commit() {
@@ -328,7 +330,7 @@ impl<'repo> App<'repo> {
         if matches!(self.mode(), AppMode::ViewBlob) {
             if let Some(pager) = &self.blob_pager {
                 self.external_editor =
-                    Some(ExternalEditor::new(&pager.blob, &pager.name, "emacsclient"));
+                    Some(ExternalEditor::new(&pager.blob, &pager.name, &self.editor));
                 self.mode_history.push(AppMode::ExternalEditor);
                 if let Some(external_editor) = &mut self.external_editor {
                     external_editor.display();

--- a/src/app.rs
+++ b/src/app.rs
@@ -364,7 +364,7 @@ impl<'repo> App<'repo> {
 
                 let blob = object
                     .into_blob()
-                    .map_err(|_| GitBrowserError::Error(ErrorKind::BlobReferenceError))?;
+                    .map_err(|_| GitBrowserError::Error(ErrorKind::BlobReference))?;
 
                 Some(ExternalEditor::new(&blob, &name, &self.editor))
             }

--- a/src/app.rs
+++ b/src/app.rs
@@ -330,6 +330,9 @@ impl<'repo> App<'repo> {
             if let Some(pager) = &self.blob_pager {
                 self.external_editor = Some(ExternalEditor::new(&pager.blob, &pager.name, "emacsclient"));
                 self.mode_history.push(AppMode::ExternalEditor);
+                if let Some(external_editor) = &mut self.external_editor {
+                    external_editor.display();
+                }
             }
         }
     }

--- a/src/app.rs
+++ b/src/app.rs
@@ -239,14 +239,21 @@ impl<'repo> App<'repo> {
     }
 
     pub fn select(&mut self) -> Result<(), GitBrowserError> {
-        if self.blob_pager.is_some() {
-            return Ok(());
-        }
-
-        let page: Box<&dyn Navigable> = if let Some(p) = self.tree_pages.last() {
-            Box::new(p)
-        } else {
-            Box::new(&self.refs_page)
+        let page: Box<&mut dyn Navigable> = match self.mode.last() {
+            Some(AppMode::BrowseRefs) => Box::new(&mut self.refs_page),
+            Some(AppMode::BrowseTrees) => Box::new(
+                self.tree_pages
+                    .last_mut()
+                    .expect("No tree browsing page in tree mode"),
+            ),
+            Some(AppMode::ViewBlob) => Box::new(
+                self.blob_pager
+                    .as_mut()
+                    .expect("No blob browser page in blob mode"),
+            ),
+            _ => {
+                return Ok(());
+            }
         };
 
         let (object, name) = match page.select() {

--- a/src/app.rs
+++ b/src/app.rs
@@ -56,7 +56,11 @@ pub struct App<'repo> {
 }
 
 impl<'repo> App<'repo> {
-    pub fn new(repo: &'repo Repository, commit_object: Option<Object<'repo>>, editor: String) -> App<'repo> {
+    pub fn new(
+        repo: &'repo Repository,
+        commit_object: Option<Object<'repo>>,
+        editor: String,
+    ) -> App<'repo> {
         let mut new = App {
             search_input: String::new(),
             repo,

--- a/src/app/blob_pager.rs
+++ b/src/app/blob_pager.rs
@@ -44,12 +44,12 @@ impl<'repo> BlobPager<'repo> {
         match object.into_blob() {
             Ok(blob) => {
                 if blob.is_binary() {
-                    Err(GitBrowserError::Error(ErrorKind::BinaryFileError))
+                    Err(GitBrowserError::Error(ErrorKind::BinaryFile))
                 } else {
                     Ok(BlobPager::new(repo, blob, name))
                 }
             }
-            Err(_) => Err(GitBrowserError::Error(ErrorKind::BlobReferenceError)),
+            Err(_) => Err(GitBrowserError::Error(ErrorKind::BlobReference)),
         }
     }
 }

--- a/src/app/blob_pager.rs
+++ b/src/app/blob_pager.rs
@@ -50,7 +50,7 @@ impl<'repo> BlobPager<'repo> {
                     Ok(BlobPager::new(repo, blob, name))
                 }
             }
-            Err(_) => panic!("peeling blob"),
+            Err(_) => Err(GitBrowserError::Error(ErrorKind::BlobReferenceError)),
         }
     }
 }

--- a/src/app/blob_pager.rs
+++ b/src/app/blob_pager.rs
@@ -17,17 +17,17 @@ use color_eyre::Result;
 use crate::errors::{ErrorKind, GitBrowserError};
 use crate::traits::{Drawable, Navigable};
 
-pub struct BlobPager {
+pub struct BlobPager<'repo> {
     top: usize,
     // repo: &'repo Repository,
-    // blob: Blob<'repo>,
-    name: String,
+    pub blob: Blob<'repo>,
+    pub name: String,
     lines: Vec<String>,
     content: Vec<u8>,
 }
 
-impl<'repo> BlobPager {
-    pub fn new(_repo: &'repo Repository, blob: Blob<'repo>, name: String) -> BlobPager {
+impl<'repo> BlobPager<'repo> {
+    pub fn new(_repo: &'repo Repository, blob: Blob<'repo>, name: String) -> BlobPager<'repo> {
         let content = blob.content();
         let utf8content = match std::str::from_utf8(content) {
             Ok(v) => v,
@@ -37,7 +37,7 @@ impl<'repo> BlobPager {
         BlobPager {
             top: 0,
             // repo: repo,
-            // blob: blob.clone(),
+            blob: blob.clone(),
             name,
             lines,
             content: content.to_owned(),
@@ -62,7 +62,7 @@ impl<'repo> BlobPager {
     }
 }
 
-impl<'repo> Drawable<'repo> for BlobPager {
+impl<'repo> Drawable<'repo> for BlobPager<'repo> {
     fn draw(&self, f: &mut Frame, area: Rect, content_block: Block) -> Rect {
         let viewport = content_block.inner(area);
         let height: usize = viewport.height.into();
@@ -108,7 +108,7 @@ impl<'repo> Drawable<'repo> for BlobPager {
     }
 }
 
-impl<'repo> Navigable<'repo> for BlobPager {
+impl<'repo> Navigable<'repo> for BlobPager<'repo> {
     fn home(&mut self, _page_size: u16) {
         self.top = 0;
     }

--- a/src/app/blob_pager.rs
+++ b/src/app/blob_pager.rs
@@ -22,12 +22,11 @@ pub struct BlobPager<'repo> {
 
 impl<'repo> BlobPager<'repo> {
     pub fn new(_repo: &'repo Repository, blob: Blob<'repo>, name: String) -> BlobPager<'repo> {
-        let content = blob.content();
-        let utf8content = match std::str::from_utf8(content) {
+        let content = match std::str::from_utf8(blob.content()) {
             Ok(v) => v,
             Err(e) => panic!("unable to decode utf8 {}", e),
         };
-        let lines = utf8content.lines().map(|line| line.to_string()).collect();
+        let lines = content.lines().map(|line| line.to_string()).collect();
         BlobPager {
             top: 0,
             // repo: repo,

--- a/src/app/external_editor.rs
+++ b/src/app/external_editor.rs
@@ -1,4 +1,11 @@
-use git2::{Blob, Object, Repository};
+use std::io::Write as _;
+use std::process::Command;
+
+use git2::Blob;
+
+use tempfile::Builder;
+
+use crate::tui;
 
 pub struct ExternalEditor {
     editor: String,
@@ -13,6 +20,31 @@ impl<'repo> ExternalEditor {
             editor: editor.to_string(),
             name: name.to_string(),
             content: blob.content().to_owned(),
+        }
+    }
+
+    pub fn display(&self) {
+        match Builder::new().suffix(&self.name).tempfile() {
+            Ok(mut tempfile) => {
+                tui::restore().expect("failed to restore terminal");
+                eprintln!("Opening {} with {} ...", self.name, self.editor);
+                let file = tempfile.as_file_mut();
+                file.write_all(&self.content).expect("failed to write file");
+
+                let mut emacsclient = Command::new(&self.editor)
+                    .arg(tempfile.path())
+                    .spawn()
+                    .expect("failed to run emacsclient");
+
+                let ecode = emacsclient
+                    .wait()
+                    .expect("failed waiting for emacsclient to exit");
+
+                assert!(ecode.success());
+                tui::init().expect("failed to reinit terminal");
+            }
+            // We should use a handlable error
+            Err(_) => panic!("unable to create temporary file"),
         }
     }
 }

--- a/src/app/external_editor.rs
+++ b/src/app/external_editor.rs
@@ -31,10 +31,14 @@ impl<'repo> ExternalEditor {
         let file = tempfile.as_file_mut();
         file.write_all(&self.content).expect("failed to write file");
 
-        let mut command = Command::new(&self.editor).arg(tempfile.path()).spawn()
+        let mut command = Command::new(&self.editor)
+            .arg(tempfile.path())
+            .spawn()
             .map_err(|_| GitBrowserError::Error(ErrorKind::SubprocessError))?;
 
-        let status = command.wait().map_err(|_| GitBrowserError::Error(ErrorKind::SubprocessError))?;
+        let status = command
+            .wait()
+            .map_err(|_| GitBrowserError::Error(ErrorKind::SubprocessError))?;
 
         if status.success() {
             Ok(())
@@ -44,7 +48,9 @@ impl<'repo> ExternalEditor {
     }
 
     pub fn display(&self) -> Result<(), GitBrowserError> {
-        let mut tempfile = Builder::new().suffix(&self.name).tempfile()
+        let mut tempfile = Builder::new()
+            .suffix(&self.name)
+            .tempfile()
             .map_err(|_| GitBrowserError::Error(ErrorKind::TemporaryFileError))?;
 
         tui::restore().map_err(|_| GitBrowserError::Error(ErrorKind::TerminalInitError))?;

--- a/src/app/external_editor.rs
+++ b/src/app/external_editor.rs
@@ -13,7 +13,6 @@ pub struct ExternalEditor {
     content: Vec<u8>,
 }
 
-
 impl<'repo> ExternalEditor {
     pub fn new(blob: &'repo Blob, name: &str, editor: &str) -> Self {
         ExternalEditor {

--- a/src/app/external_editor.rs
+++ b/src/app/external_editor.rs
@@ -33,11 +33,11 @@ impl<'repo> ExternalEditor {
                 let mut emacsclient = Command::new(&self.editor)
                     .arg(tempfile.path())
                     .spawn()
-                    .expect("failed to run emacsclient");
+                    .expect("failed to run external pager");
 
                 let ecode = emacsclient
                     .wait()
-                    .expect("failed waiting for emacsclient to exit");
+                    .expect("failed waiting for pager to exit");
 
                 assert!(ecode.success());
                 tui::init().expect("failed to reinit terminal");

--- a/src/app/external_editor.rs
+++ b/src/app/external_editor.rs
@@ -1,0 +1,18 @@
+use git2::{Blob, Object, Repository};
+
+pub struct ExternalEditor {
+    editor: String,
+    name: String,
+    content: Vec<u8>,
+}
+
+
+impl<'repo> ExternalEditor {
+    pub fn new(blob: &'repo Blob, name: &str, editor: &str) -> Self {
+        ExternalEditor {
+            editor: editor.to_string(),
+            name: name.to_string(),
+            content: blob.content().to_owned(),
+        }
+    }
+}

--- a/src/app/external_editor.rs
+++ b/src/app/external_editor.rs
@@ -59,18 +59,12 @@ impl<'repo> ExternalEditor {
                 }
                 eprintln!("Opening {} with {} ...", self.name, self.editor);
 
-                match self.spawn_editor(&mut tempfile) {
-                    Ok(_) => {}
-                    Err(e) => {
-                        if tui::init().is_err() {
-                            return Err(GitBrowserError::Error(ErrorKind::TerminalInitError));
-                        }
-                        return Err(e);
-                    }
-                }
-
+                let error = self.spawn_editor(&mut tempfile).err();
                 if tui::init().is_err() {
                     return Err(GitBrowserError::Error(ErrorKind::TerminalInitError));
+                }
+                if let Some(e) = error {
+                    return Err(e);
                 }
             }
             Err(_) => {

--- a/src/app/external_editor.rs
+++ b/src/app/external_editor.rs
@@ -34,16 +34,16 @@ impl<'repo> ExternalEditor {
         let mut command = Command::new(&self.editor)
             .arg(tempfile.path())
             .spawn()
-            .map_err(|_| GitBrowserError::Error(ErrorKind::SubprocessError))?;
+            .map_err(|_| GitBrowserError::Error(ErrorKind::Subprocess))?;
 
         let status = command
             .wait()
-            .map_err(|_| GitBrowserError::Error(ErrorKind::SubprocessError))?;
+            .map_err(|_| GitBrowserError::Error(ErrorKind::Subprocess))?;
 
         if status.success() {
             Ok(())
         } else {
-            Err(GitBrowserError::Error(ErrorKind::SubprocessError))
+            Err(GitBrowserError::Error(ErrorKind::Subprocess))
         }
     }
 
@@ -51,13 +51,13 @@ impl<'repo> ExternalEditor {
         let mut tempfile = Builder::new()
             .suffix(&self.name)
             .tempfile()
-            .map_err(|_| GitBrowserError::Error(ErrorKind::TemporaryFileError))?;
+            .map_err(|_| GitBrowserError::Error(ErrorKind::TemporaryFile))?;
 
-        tui::restore().map_err(|_| GitBrowserError::Error(ErrorKind::TerminalInitError))?;
+        tui::restore().map_err(|_| GitBrowserError::Error(ErrorKind::TerminalInit))?;
         eprintln!("Opening {} with {} ...", self.name, self.editor);
 
         let error = self.spawn_editor(&mut tempfile).err();
-        tui::init().map_err(|_| GitBrowserError::Error(ErrorKind::TerminalInitError))?;
+        tui::init().map_err(|_| GitBrowserError::Error(ErrorKind::TerminalInit))?;
 
         if let Some(e) = error {
             return Err(e);

--- a/src/app/navigation.rs
+++ b/src/app/navigation.rs
@@ -1,5 +1,6 @@
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
+#[derive(Debug)]
 pub enum NavigationAction {
     Select,
     Back,

--- a/src/app/navigation.rs
+++ b/src/app/navigation.rs
@@ -9,6 +9,7 @@ pub enum NavigationAction {
     PageDown,
     NextSelection,
     PreviousSelection,
+    ExternalEditor,
     Invalid,
 }
 
@@ -16,20 +17,23 @@ impl From<KeyEvent> for NavigationAction {
     fn from(key: KeyEvent) -> NavigationAction {
         match (key.code, key.modifiers.bits()) {
             (KeyCode::Enter, 0) => NavigationAction::Select,
-            (KeyCode::Char('g'), modifiers) => {
-                if modifiers == KeyModifiers::CONTROL.bits() {
-                    NavigationAction::Back
-                } else {
-                    NavigationAction::Invalid
-                }
-            }
             (KeyCode::Home, 0) => NavigationAction::Home,
             (KeyCode::End, 0) => NavigationAction::End,
             (KeyCode::PageUp, 0) => NavigationAction::PageUp,
             (KeyCode::PageDown, 0) => NavigationAction::PageDown,
             (KeyCode::Up, 0) => NavigationAction::PreviousSelection,
             (KeyCode::Down, 0) => NavigationAction::NextSelection,
-            _ => NavigationAction::Invalid,
+            (keycode, modifiers) => {
+                if modifiers == KeyModifiers::CONTROL.bits() {
+                    match keycode {
+                        KeyCode::Char('g') => NavigationAction::Back,
+                        KeyCode::Char('e') => NavigationAction::ExternalEditor,
+                        _ => NavigationAction::Invalid,
+                    }
+                } else {
+                    NavigationAction::Invalid
+                }
+            }
         }
     }
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -43,6 +43,9 @@ impl GitBrowserError {
 pub enum ErrorKind {
     BinaryFileError,
     BlobReferenceError,
+    SubprocessError,
+    TemporaryFileError,
+    TerminalInitError,
 }
 
 impl ErrorKind {
@@ -50,6 +53,9 @@ impl ErrorKind {
         match *self {
             ErrorKind::BinaryFileError => "Unable to load and display binary files",
             ErrorKind::BlobReferenceError => "Unable to load blob from repository",
+            ErrorKind::SubprocessError => "Failed to execute subprocess",
+            ErrorKind::TemporaryFileError => "Failed to write temporary file",
+            ErrorKind::TerminalInitError => "Failed to reinitialize terminal",
         }
     }
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -41,21 +41,21 @@ impl GitBrowserError {
 
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub enum ErrorKind {
-    BinaryFileError,
-    BlobReferenceError,
-    SubprocessError,
-    TemporaryFileError,
-    TerminalInitError,
+    BinaryFile,
+    BlobReference,
+    Subprocess,
+    TemporaryFile,
+    TerminalInit,
 }
 
 impl ErrorKind {
     pub fn as_str(&self) -> &str {
         match *self {
-            ErrorKind::BinaryFileError => "Unable to load and display binary files",
-            ErrorKind::BlobReferenceError => "Unable to load blob from repository",
-            ErrorKind::SubprocessError => "Failed to execute subprocess",
-            ErrorKind::TemporaryFileError => "Failed to write temporary file",
-            ErrorKind::TerminalInitError => "Failed to reinitialize terminal",
+            ErrorKind::BinaryFile => "Unable to load and display binary files",
+            ErrorKind::BlobReference => "Unable to load blob from repository",
+            ErrorKind::Subprocess => "Failed to execute subprocess",
+            ErrorKind::TemporaryFile => "Failed to write temporary file",
+            ErrorKind::TerminalInit => "Failed to reinitialize terminal",
         }
     }
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -42,12 +42,14 @@ impl GitBrowserError {
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub enum ErrorKind {
     BinaryFileError,
+    BlobReferenceError,
 }
 
 impl ErrorKind {
     pub fn as_str(&self) -> &str {
         match *self {
             ErrorKind::BinaryFileError => "Unable to load and display binary files",
+            ErrorKind::BlobReferenceError => "Unable to load blob from repository",
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -91,7 +91,7 @@ fn run_app<B: Backend>(terminal: &mut Terminal<B>, app: &mut App) -> Result<bool
             }
             let navigation_action = NavigationAction::from(key);
             clear = matches!(navigation_action, NavigationAction::ExternalEditor);
-            if let Err(error) = app.navigate(navigation_action) {
+            if let Err(error) = app.navigate(&navigation_action) {
                 app.error(error);
             }
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -74,14 +74,10 @@ fn run_app<B: Backend>(terminal: &mut Terminal<B>, app: &mut App) -> Result<bool
                 return Ok(true);
             }
             let navigation_action = NavigationAction::from(key);
-            match navigation_action {
-                NavigationAction::ExternalEditor => {
-                    clear = true;
-                }
-                _ => {
-                    clear = false;
-                }
-            }
+            clear = match navigation_action {
+                NavigationAction::ExternalEditor => true,
+                _ => false,
+            };
             if let Err(error) = app.navigate(navigation_action) {
                 app.error(error);
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -56,7 +56,11 @@ fn main() -> Result<()> {
 }
 
 fn run_app<B: Backend>(terminal: &mut Terminal<B>, app: &mut App) -> Result<bool> {
+    let mut clear = false;
     loop {
+        if clear {
+            terminal.clear()?;
+        }
         terminal.draw(|f| ui(f, app))?;
 
         let read_event = event::read()?;
@@ -70,6 +74,14 @@ fn run_app<B: Backend>(terminal: &mut Terminal<B>, app: &mut App) -> Result<bool
                 return Ok(true);
             }
             let navigation_action = NavigationAction::from(key);
+            match navigation_action {
+                NavigationAction::ExternalEditor => {
+                    clear = true;
+                }
+                _ => {
+                    clear = false;
+                }
+            }
             if let Err(error) = app.navigate(navigation_action) {
                 app.error(error);
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,5 @@
+use std::env;
+
 use crossterm::event::{self, Event, KeyCode, KeyEventKind, KeyModifiers};
 use ratatui::{backend::Backend, Terminal};
 
@@ -24,6 +26,9 @@ struct Args {
 
     #[arg(short, long)]
     commit_id: Option<String>,
+
+    #[arg(short, long)]
+    pager: Option<String>,
 }
 
 fn main() -> Result<()> {
@@ -48,8 +53,19 @@ fn main() -> Result<()> {
         _ => None,
     };
 
+    let pager = match args.pager {
+        Some(pager) => pager,
+        None => {
+            if let Some(pager) = env::var_os("PAGER") {
+                pager.into_string().expect("Unable to decode PAGER env var")
+            } else {
+                "less".to_string()
+            }
+        }
+    };
+
     let mut terminal = tui::init()?;
-    let mut app = App::new(&repo, commit);
+    let mut app = App::new(&repo, commit, pager);
     run_app(&mut terminal, &mut app)?;
     tui::restore()?;
     Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -90,9 +90,12 @@ fn run_app<B: Backend>(terminal: &mut Terminal<B>, app: &mut App) -> Result<bool
                 return Ok(true);
             }
             let navigation_action = NavigationAction::from(key);
-            clear = matches!(navigation_action, NavigationAction::ExternalEditor);
-            if let Err(error) = app.navigate(&navigation_action) {
-                app.error(error);
+            clear = match app.navigate(&navigation_action) {
+                Ok(clear) => clear,
+                Err(error) => {
+                    app.error(error);
+                    true
+                }
             }
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -72,9 +72,9 @@ fn main() -> Result<()> {
 }
 
 fn run_app<B: Backend>(terminal: &mut Terminal<B>, app: &mut App) -> Result<bool> {
-    let mut clear = false;
+    let mut redraw = false;
     loop {
-        if clear {
+        if redraw {
             terminal.clear()?;
         }
         terminal.draw(|f| ui(f, app))?;
@@ -90,8 +90,8 @@ fn run_app<B: Backend>(terminal: &mut Terminal<B>, app: &mut App) -> Result<bool
                 return Ok(true);
             }
             let navigation_action = NavigationAction::from(key);
-            clear = match app.navigate(&navigation_action) {
-                Ok(clear) => clear,
+            redraw = match app.navigate(&navigation_action) {
+                Ok(redraw) => redraw.0,
                 Err(error) => {
                     app.error(error);
                     true

--- a/src/main.rs
+++ b/src/main.rs
@@ -90,10 +90,7 @@ fn run_app<B: Backend>(terminal: &mut Terminal<B>, app: &mut App) -> Result<bool
                 return Ok(true);
             }
             let navigation_action = NavigationAction::from(key);
-            clear = match navigation_action {
-                NavigationAction::ExternalEditor => true,
-                _ => false,
-            };
+            clear = matches!(navigation_action, NavigationAction::ExternalEditor);
             if let Err(error) = app.navigate(navigation_action) {
                 app.error(error);
             }


### PR DESCRIPTION
Allow opening files in external viewer.

Currently hardcoded to `emacsclient`, but will change to use `PAGER` and `EDITOR` environment variables.