### PR TITLE
Syntax highlighting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -397,6 +397,7 @@ dependencies = [
  "ratatui",
  "syntect",
  "tempfile",
+ "two-face",
 ]
 
 [[package]]
@@ -1219,6 +1220,17 @@ dependencies = [
  "sharded-slab",
  "thread_local",
  "tracing-core",
+]
+
+[[package]]
+name = "two-face"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ccd4843ea031c609fe9c16cae00e9657bad8a9f735a3cc2e420955d802b4268"
+dependencies = [
+ "once_cell",
+ "serde",
+ "syntect",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -106,6 +106,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "base64"
+version = "0.21.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+
+[[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
 name = "bitflags"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -230,12 +251,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc32fast"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "crossterm"
 version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f476fe445d41c9e991fd07515a6f463074b782242ccf4a5b7b1d1012e70824df"
 dependencies = [
- "bitflags",
+ "bitflags 2.5.0",
  "crossterm_winapi",
  "libc",
  "mio",
@@ -255,6 +285,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "deranged"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
+dependencies = [
+ "powerfmt",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -270,6 +309,12 @@ name = "either"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3dca9240753cf90908d7e4aac30f630662b02aebaa1b58a3cadabdb23385b58b"
+
+[[package]]
+name = "equivalent"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
@@ -298,6 +343,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fc0510504f03c51ada170672ac806f1f105a88aa97a5281117e1ddc3368e51a"
 
 [[package]]
+name = "flate2"
+version = "1.0.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f54427cfd1c7829e2a139fcefea601bf088ebca651d2bf53ebc600eac295dae"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -318,7 +379,7 @@ version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b903b73e45dc0c6c596f2d37eccece7c1c8bb6e4407b001096387c63d0d93724"
 dependencies = [
- "bitflags",
+ "bitflags 2.5.0",
  "libc",
  "libgit2-sys",
  "log",
@@ -334,6 +395,7 @@ dependencies = [
  "crossterm",
  "git2",
  "ratatui",
+ "syntect",
  "tempfile",
 ]
 
@@ -490,6 +552,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
 
 [[package]]
+name = "indexmap"
+version = "2.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
+dependencies = [
+ "equivalent",
+ "hashbrown",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -556,6 +628,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "line-wrap"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd1bc4d24ad230d21fb898d1116b1801d7adfc449d42026475862ab48b11e70e"
+
+[[package]]
+name = "linked-hash-map"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -620,6 +704,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-conv"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
 name = "object"
 version = "0.32.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -633,6 +723,28 @@ name = "once_cell"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+
+[[package]]
+name = "onig"
+version = "6.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c4b31c8722ad9171c6d77d3557db078cab2bd50afcc9d09c8b315c59df8ca4f"
+dependencies = [
+ "bitflags 1.3.2",
+ "libc",
+ "once_cell",
+ "onig_sys",
+]
+
+[[package]]
+name = "onig_sys"
+version = "69.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b829e3d7e9cc74c7e315ee8edb185bf4190da5acde74afd7fc59c35b1f086e7"
+dependencies = [
+ "cc",
+ "pkg-config",
+]
 
 [[package]]
 name = "owo-colors"
@@ -688,12 +800,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
 
 [[package]]
+name = "plist"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9d34169e64b3c7a80c8621a48adaf44e0cf62c78a9b25dd9dd35f1881a17cf9"
+dependencies = [
+ "base64",
+ "indexmap",
+ "line-wrap",
+ "quick-xml",
+ "serde",
+ "time",
+]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22244ce15aa966053a896d1accb3a6e68469b97c7f33f284b99f0d576879fc23"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1004a344b30a54e2ee58d66a71b32d2db2feb0a31f9a2d302bf0536f15de2a33"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -711,7 +852,7 @@ version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f44c9e68fd46eda15c646fbb85e1040b657a58cdc8c98db1d97a55930d991eef"
 dependencies = [
- "bitflags",
+ "bitflags 2.5.0",
  "cassowary",
  "compact_str",
  "crossterm",
@@ -731,8 +872,14 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c82cf8cff14456045f55ec4241383baeff27af886adb72ffb2162f99911de0fd"
 dependencies = [
- "bitflags",
+ "bitflags 2.5.0",
 ]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
 
 [[package]]
 name = "rustc-demangle"
@@ -746,7 +893,7 @@ version = "0.38.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f"
 dependencies = [
- "bitflags",
+ "bitflags 2.5.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -764,6 +911,15 @@ name = "ryu"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "scopeguard"
@@ -789,6 +945,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "455182ea6142b14f93f4bc5320a2b31c1f266b66a4a5c858b013302a5d8cbfc3"
+dependencies = [
+ "itoa",
+ "ryu",
+ "serde",
 ]
 
 [[package]]
@@ -909,6 +1076,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "syntect"
+version = "5.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "874dcfa363995604333cf947ae9f751ca3af4522c60886774c4963943b4746b1"
+dependencies = [
+ "bincode",
+ "bitflags 1.3.2",
+ "flate2",
+ "fnv",
+ "once_cell",
+ "onig",
+ "plist",
+ "regex-syntax",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "thiserror",
+ "walkdir",
+ "yaml-rust",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -921,6 +1110,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "thiserror"
+version = "1.0.61"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c546c80d6be4bc6a00c0f01730c08df82eaa7a7a61f11d656526506112cc1709"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.61"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46c3384250002a6d5af4d114f2845d37b57521033f30d5c3f46c4d70e1197533"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "thread_local"
 version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -928,6 +1137,37 @@ checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
 dependencies = [
  "cfg-if",
  "once_cell",
+]
+
+[[package]]
+name = "time"
+version = "0.3.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
+
+[[package]]
+name = "time-macros"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
+dependencies = [
+ "num-conv",
+ "time-core",
 ]
 
 [[package]]
@@ -1057,6 +1297,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1077,6 +1327,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d4cc384e1e73b93bafa6fb4f1df8c41695c8a91cf9c4c64358067d15a7b6c6b"
+dependencies = [
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"
@@ -1234,6 +1493,15 @@ name = "writeable"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
+
+[[package]]
+name = "yaml-rust"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
+dependencies = [
+ "linked-hash-map",
+]
 
 [[package]]
 name = "yoke"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,3 +16,11 @@ ratatui = "0.26.3"
 syntect = "5.2.0"
 tempfile = "3.10.1"
 two-face = { version = "0.4.0", features = ["syntect-default-onig"] }
+
+[profile.dev.package."*"]
+# Set the default for dependencies in Development mode.
+opt-level = 3
+
+[profile.dev]
+# Turn on a small amount of optimisation in Development mode.
+opt-level = 1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,4 @@ git2 = { version = "0.19.0", default-features = false }
 ratatui = "0.26.3"
 syntect = "5.2.0"
 tempfile = "3.10.1"
+two-face = { version = "0.4.0", features = ["syntect-default-onig"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,4 +13,5 @@ color-eyre = "0.6.3"
 crossterm = "0.27.0"
 git2 = { version = "0.19.0", default-features = false }
 ratatui = "0.26.3"
+syntect = "5.2.0"
 tempfile = "3.10.1"

--- a/src/app.rs
+++ b/src/app.rs
@@ -55,7 +55,7 @@ pub struct App<'repo, 'syntax> {
     commit: Option<Commit<'repo>>,
     refs_page: RefsPage<'repo>,
     tree_pages: Vec<TreePage<'repo>>,
-    blob_pager: Option<BlobPager<'repo, 'syntax>>,
+    blob_pager: Option<BlobPager<'repo>>,
     external_editor: Option<ExternalEditor>,
     mode_history: Vec<AppMode>,
     height: u16,

--- a/src/app.rs
+++ b/src/app.rs
@@ -339,8 +339,8 @@ impl<'repo, 'syntax> App<'repo, 'syntax> {
                     self.repo,
                     object,
                     page.selected_item(),
-                    &self.syntax_set,
-                    &self.theme,
+                    self.syntax_set,
+                    self.theme,
                 )?;
                 self.blob_pager = Some(pager);
                 self.mode_history.push(AppMode::ViewBlob);

--- a/src/app.rs
+++ b/src/app.rs
@@ -55,7 +55,7 @@ pub struct App<'repo, 'syntax> {
     commit: Option<Commit<'repo>>,
     refs_page: RefsPage<'repo>,
     tree_pages: Vec<TreePage<'repo>>,
-    blob_pager: Option<BlobPager<'repo>>,
+    blob_pager: Option<BlobPager<'repo, 'syntax>>,
     external_editor: Option<ExternalEditor>,
     mode_history: Vec<AppMode>,
     height: u16,

--- a/src/app.rs
+++ b/src/app.rs
@@ -291,9 +291,14 @@ impl<'repo, 'syntax> App<'repo, 'syntax> {
         };
 
         match action {
-            NavigationAction::Tick => page.next_tick(),
+            NavigationAction::Tick => {
+                page.next_tick(false)?;
+            }
             NavigationAction::Home => page.home(self.height),
-            NavigationAction::End => page.end(self.height),
+            NavigationAction::End => {
+                page.next_tick(true)?;
+                page.end(self.height);
+            }
             NavigationAction::PageUp => page.pageup(self.height),
             NavigationAction::PageDown => page.pagedown(self.height),
             NavigationAction::NextSelection => page.next_selection(),

--- a/src/app.rs
+++ b/src/app.rs
@@ -291,6 +291,7 @@ impl<'repo, 'syntax> App<'repo, 'syntax> {
         };
 
         match action {
+            NavigationAction::Tick => page.next_tick(),
             NavigationAction::Home => page.home(self.height),
             NavigationAction::End => page.end(self.height),
             NavigationAction::PageUp => page.pageup(self.height),

--- a/src/app.rs
+++ b/src/app.rs
@@ -14,8 +14,8 @@ use ratatui::{
 
 use color_eyre::Result;
 
-use syntect::parsing::SyntaxSet;
 use syntect::highlighting;
+use syntect::parsing::SyntaxSet;
 
 use crate::{
     traits::{Drawable, Navigable},
@@ -336,8 +336,11 @@ impl<'repo, 'syntax> App<'repo, 'syntax> {
         match object.kind() {
             Some(ObjectType::Blob) => {
                 let pager = BlobPager::from_object(
-                    self.repo, object, page.selected_item(),
-                    &self.syntax_set, &self.theme,
+                    self.repo,
+                    object,
+                    page.selected_item(),
+                    &self.syntax_set,
+                    &self.theme,
                 )?;
                 self.blob_pager = Some(pager);
                 self.mode_history.push(AppMode::ViewBlob);

--- a/src/app/blob_pager.rs
+++ b/src/app/blob_pager.rs
@@ -15,7 +15,7 @@ use color_eyre::Result;
 
 use syntect::easy::HighlightLines;
 use syntect::highlighting;
-use syntect::parsing::{SyntaxSet};
+use syntect::parsing::SyntaxSet;
 
 use crate::errors::{ErrorKind, GitBrowserError};
 use crate::traits::{Drawable, Navigable};
@@ -243,13 +243,14 @@ impl<'repo, 'syntax> Navigable<'repo> for BlobPager<'repo, 'syntax> {
         "".to_string()
     }
 
-    fn next_tick(&mut self) {
+    fn next_tick(&mut self, block: bool) -> Result<(), GitBrowserError> {
         if self.raw_lines.is_empty() {
-            return;
+            return Ok(());
         }
 
         let mut count = 0;
-        while count < 100 && !self.raw_lines.is_empty() {
+        let max_items = if block { self.raw_lines.len() } else { 100 };
+        while count < max_items && !self.raw_lines.is_empty() {
             count += 1;
             let text = self.raw_lines.pop_front().unwrap();
             let line = match &mut self.highlighter {
@@ -261,5 +262,7 @@ impl<'repo, 'syntax> Navigable<'repo> for BlobPager<'repo, 'syntax> {
 
             self.lines.push(line);
         }
+
+        Ok(())
     }
 }

--- a/src/app/blob_pager.rs
+++ b/src/app/blob_pager.rs
@@ -43,20 +43,29 @@ impl<'a> From<Vec<(highlighting::Style, &'a str)>> for HighlightedLine {
         HighlightedLine {
             components: value
                 .iter()
-                .map(|(style, text)| (to_style(style), text.to_string()))
+                .map(|(style, text)| (TuiStyle::from(style).0, text.to_string()))
                 .collect(),
         }
     }
 }
 
-fn to_color(hcolor: &highlighting::Color) -> Color {
-    Color::Rgb(hcolor.r, hcolor.g, hcolor.b)
+struct TuiColor(Color);
+struct TuiStyle(Style);
+
+impl From<&highlighting::Color> for TuiColor {
+    fn from(color: &highlighting::Color) -> TuiColor {
+        TuiColor(Color::Rgb(color.r, color.g, color.b))
+    }
 }
 
-fn to_style(hstyle: &highlighting::Style) -> Style {
-    Style::default()
-        .fg(to_color(&hstyle.foreground))
-        .bg(to_color(&hstyle.background))
+impl From<&highlighting::Style> for TuiStyle {
+    fn from(style: &highlighting::Style) -> TuiStyle {
+        TuiStyle(
+            Style::default()
+                .fg(TuiColor::from(&style.foreground).0)
+                .bg(TuiColor::from(&style.background).0),
+        )
+    }
 }
 
 impl<'repo, 'syntax> BlobPager<'repo, 'syntax> {
@@ -86,7 +95,7 @@ impl<'repo, 'syntax> BlobPager<'repo, 'syntax> {
         let background_style = match syntax {
             Some(_) => {
                 if let Some(color) = theme.settings.background {
-                    Style::default().bg(to_color(&color))
+                    Style::default().bg(TuiColor::from(&color).0)
                 } else {
                     Style::default()
                 }

--- a/src/app/blob_pager.rs
+++ b/src/app/blob_pager.rs
@@ -60,8 +60,13 @@ fn to_style(hstyle: &highlighting::Style) -> Style {
 }
 
 impl<'repo, 'syntax> BlobPager<'repo, 'syntax> {
-    pub fn new(_repo: &'repo Repository, blob: Blob<'repo>, name: String,
-               syntax_set: &'syntax SyntaxSet, theme: &'syntax highlighting::Theme) -> BlobPager<'repo, 'syntax> {
+    pub fn new(
+        _repo: &'repo Repository,
+        blob: Blob<'repo>,
+        name: String,
+        syntax_set: &'syntax SyntaxSet,
+        theme: &'syntax highlighting::Theme,
+    ) -> BlobPager<'repo, 'syntax> {
         let content = match std::str::from_utf8(blob.content()) {
             Ok(v) => v,
             Err(e) => panic!("unable to decode utf8 {}", e),

--- a/src/app/blob_pager.rs
+++ b/src/app/blob_pager.rs
@@ -30,14 +30,14 @@ pub struct BlobPager<'repo> {
     theme_set: two_face::theme::EmbeddedLazyThemeSet,
 }
 
-fn to_color(hcolor: highlighting::Color) -> Color {
+fn to_color(hcolor: &highlighting::Color) -> Color {
     Color::Rgb(hcolor.r, hcolor.g, hcolor.b)
 }
 
-fn to_style(hstyle: highlighting::Style) -> Style {
+fn to_style(hstyle: &highlighting::Style) -> Style {
     Style::default()
-        .fg(to_color(hstyle.foreground))
-        .bg(to_color(hstyle.background))
+        .fg(to_color(&hstyle.foreground))
+        .bg(to_color(&hstyle.background))
 }
 
 impl<'repo> BlobPager<'repo> {
@@ -92,7 +92,7 @@ impl<'repo> Drawable<'repo> for BlobPager<'repo> {
         let style = match syntax {
             Some(_) => {
                 if let Some(color) = theme.settings.background {
-                    Style::default().bg(to_color(color))
+                    Style::default().bg(to_color(&color))
                 } else {
                     Style::default()
                 }
@@ -139,7 +139,7 @@ impl<'repo> Drawable<'repo> for BlobPager<'repo> {
                         let ranges: Vec<(highlighting::Style, &str)> =
                             h.highlight_line(text, &self.syntax_set).unwrap();
                         for (style, part) in ranges.iter() {
-                            parts.push(Span::styled(*part, to_style(style.clone())));
+                            parts.push(Span::styled(*part, to_style(style)));
                         }
                         parts
                     }

--- a/src/app/blob_pager.rs
+++ b/src/app/blob_pager.rs
@@ -14,23 +14,23 @@ use color_eyre::Result;
 
 use syntect::easy::HighlightLines;
 use syntect::highlighting;
-use syntect::parsing::SyntaxSet;
+use syntect::parsing::{SyntaxReference, SyntaxSet};
 use two_face::re_exports::syntect;
 
 use crate::errors::{ErrorKind, GitBrowserError};
 use crate::traits::{Drawable, Navigable};
 
-pub struct BlobPager<'repo> {
+pub struct BlobPager<'repo, 'syntax> {
     top: usize,
     // repo: &'repo Repository,
     pub blob: Blob<'repo>,
     pub name: String,
     background_style: Style,
-    // syntax_set: &'syntax SyntaxSet,
-    // syntax: Option<SyntaxReference>,
-    // theme: &'syntax highlighting::Theme,
-    // highlighter: Option<HighlightLines<'syntax>>,
-    // raw_lines: Vec<String>,
+    syntax_set: &'syntax SyntaxSet,
+    syntax: Option<SyntaxReference>,
+    theme: &'syntax highlighting::Theme,
+    highlighter: Option<HighlightLines<'syntax>>,
+    raw_lines: Vec<String>,
     lines: Vec<HighlightedLine>,
 }
 
@@ -59,14 +59,14 @@ fn to_style(hstyle: &highlighting::Style) -> Style {
         .bg(to_color(&hstyle.background))
 }
 
-impl<'repo> BlobPager<'repo> {
+impl<'repo, 'syntax> BlobPager<'repo, 'syntax> {
     pub fn new(
         _repo: &'repo Repository,
         blob: Blob<'repo>,
         name: String,
-        syntax_set: &SyntaxSet,
-        theme: &highlighting::Theme,
-    ) -> BlobPager<'repo> {
+        syntax_set: &'syntax SyntaxSet,
+        theme: &'syntax highlighting::Theme,
+    ) -> BlobPager<'repo, 'syntax> {
         let content = match std::str::from_utf8(blob.content()) {
             Ok(v) => v,
             Err(e) => panic!("unable to decode utf8 {}", e),
@@ -112,11 +112,11 @@ impl<'repo> BlobPager<'repo> {
             blob: blob.clone(),
             name,
             background_style,
-            // syntax_set,
-            // syntax,
-            // theme,
-            // highlighter,
-            // raw_lines,
+            syntax_set,
+            syntax,
+            theme,
+            highlighter,
+            raw_lines,
             lines,
         }
     }
@@ -125,8 +125,8 @@ impl<'repo> BlobPager<'repo> {
         repo: &'repo Repository,
         object: Object<'repo>,
         name: String,
-        syntax_set: &SyntaxSet,
-        theme: &highlighting::Theme,
+        syntax_set: &'syntax SyntaxSet,
+        theme: &'syntax highlighting::Theme,
     ) -> Result<Self, GitBrowserError> {
         match object.into_blob() {
             Ok(blob) => {
@@ -141,7 +141,7 @@ impl<'repo> BlobPager<'repo> {
     }
 }
 
-impl<'repo> Drawable<'repo> for BlobPager<'repo> {
+impl<'repo, 'syntax> Drawable<'repo> for BlobPager<'repo, 'syntax> {
     fn draw(&self, f: &mut Frame, area: Rect, content_block_ext: Block) -> Rect {
         let content_block = content_block_ext.style(self.background_style);
 
@@ -199,7 +199,7 @@ impl<'repo> Drawable<'repo> for BlobPager<'repo> {
     }
 }
 
-impl<'repo> Navigable<'repo> for BlobPager<'repo> {
+impl<'repo, 'syntax> Navigable<'repo> for BlobPager<'repo, 'syntax> {
     fn home(&mut self, _page_size: u16) {
         self.top = 0;
     }

--- a/src/app/blob_pager.rs
+++ b/src/app/blob_pager.rs
@@ -94,12 +94,12 @@ impl<'repo, 'syntax> BlobPager<'repo, 'syntax> {
             _ => Style::default(),
         };
 
-        let mut highlighter = syntax.as_ref().map(|s| HighlightLines::new(s, &theme));
+        let mut highlighter = syntax.as_ref().map(|s| HighlightLines::new(s, theme));
 
         let lines: Vec<HighlightedLine> = raw_lines
             .iter()
             .map(|text| match &mut highlighter {
-                Some(h) => HighlightedLine::from(h.highlight_line(text, &syntax_set).unwrap()),
+                Some(h) => HighlightedLine::from(h.highlight_line(text, syntax_set).unwrap()),
                 _ => HighlightedLine {
                     components: vec![(Style::default(), text.to_string())],
                 },

--- a/src/app/blob_pager.rs
+++ b/src/app/blob_pager.rs
@@ -1,6 +1,7 @@
 use std::collections::VecDeque;
 use std::ffi::OsStr;
 use std::path::Path;
+use std::time::Instant;
 
 use git2::{Blob, Object, Repository};
 
@@ -257,10 +258,8 @@ impl<'repo, 'syntax> Navigable<'repo> for BlobPager<'repo, 'syntax> {
             return Ok(());
         }
 
-        let mut count = 0;
-        let max_items = if block { self.raw_lines.len() } else { 100 };
-        while count < max_items && !self.raw_lines.is_empty() {
-            count += 1;
+        let iteration = Instant::now();
+        while (block || iteration.elapsed().as_millis() < 150) && !self.raw_lines.is_empty() {
             let text = self.raw_lines.pop_front().unwrap();
             let line = match &mut self.highlighter {
                 Some(h) => HighlightedLine::from(h.highlight_line(&text, self.syntax_set).unwrap()),

--- a/src/app/blob_pager.rs
+++ b/src/app/blob_pager.rs
@@ -68,12 +68,15 @@ impl<'repo, 'syntax> BlobPager<'repo, 'syntax> {
         };
         let raw_lines: Vec<String> = content.lines().map(|line| line.to_string()).collect();
 
-        let syntax = match Path::new(&name).extension().and_then(OsStr::to_str) {
-            Some(ext) => syntax_set.find_syntax_by_extension(ext).cloned(),
-            _ => match raw_lines.first() {
-                Some(line) => syntax_set.find_syntax_by_first_line(line).cloned(),
-                _ => None,
-            },
+        let syntax = {
+            let extension = Path::new(&name).extension().and_then(OsStr::to_str);
+            if let Some(ext) = extension {
+                syntax_set.find_syntax_by_extension(ext).cloned()
+            } else if let Some(line) = raw_lines.first() {
+                syntax_set.find_syntax_by_first_line(line).cloned()
+            } else {
+                None
+            }
         };
         let background_style = match syntax {
             Some(_) => {

--- a/src/app/blob_pager.rs
+++ b/src/app/blob_pager.rs
@@ -84,7 +84,7 @@ impl<'repo> Drawable<'repo> for BlobPager<'repo> {
         let syntax = match Path::new(&self.name).extension().and_then(OsStr::to_str) {
             Some(ext) => self.syntax_set.find_syntax_by_extension(ext),
             _ => match self.lines.first() {
-                Some(line) => self.syntax_set.find_syntax_by_first_line(&line),
+                Some(line) => self.syntax_set.find_syntax_by_first_line(line),
                 _ => None,
             },
         };

--- a/src/app/blob_pager.rs
+++ b/src/app/blob_pager.rs
@@ -14,23 +14,23 @@ use color_eyre::Result;
 
 use syntect::easy::HighlightLines;
 use syntect::highlighting;
-use syntect::parsing::{SyntaxReference, SyntaxSet};
+use syntect::parsing::SyntaxSet;
 use two_face::re_exports::syntect;
 
 use crate::errors::{ErrorKind, GitBrowserError};
 use crate::traits::{Drawable, Navigable};
 
-pub struct BlobPager<'repo, 'syntax> {
+pub struct BlobPager<'repo> {
     top: usize,
     // repo: &'repo Repository,
     pub blob: Blob<'repo>,
     pub name: String,
     background_style: Style,
-    syntax_set: &'syntax SyntaxSet,
-    syntax: Option<SyntaxReference>,
-    theme: &'syntax highlighting::Theme,
-    highlighter: Option<HighlightLines<'syntax>>,
-    raw_lines: Vec<String>,
+    // syntax_set: &'syntax SyntaxSet,
+    // syntax: Option<SyntaxReference>,
+    // theme: &'syntax highlighting::Theme,
+    // highlighter: Option<HighlightLines<'syntax>>,
+    // raw_lines: Vec<String>,
     lines: Vec<HighlightedLine>,
 }
 
@@ -59,14 +59,14 @@ fn to_style(hstyle: &highlighting::Style) -> Style {
         .bg(to_color(&hstyle.background))
 }
 
-impl<'repo, 'syntax> BlobPager<'repo, 'syntax> {
+impl<'repo> BlobPager<'repo> {
     pub fn new(
         _repo: &'repo Repository,
         blob: Blob<'repo>,
         name: String,
-        syntax_set: &'syntax SyntaxSet,
-        theme: &'syntax highlighting::Theme,
-    ) -> BlobPager<'repo, 'syntax> {
+        syntax_set: &SyntaxSet,
+        theme: &highlighting::Theme,
+    ) -> BlobPager<'repo> {
         let content = match std::str::from_utf8(blob.content()) {
             Ok(v) => v,
             Err(e) => panic!("unable to decode utf8 {}", e),
@@ -112,11 +112,11 @@ impl<'repo, 'syntax> BlobPager<'repo, 'syntax> {
             blob: blob.clone(),
             name,
             background_style,
-            syntax_set,
-            syntax,
-            theme,
-            highlighter,
-            raw_lines,
+            // syntax_set,
+            // syntax,
+            // theme,
+            // highlighter,
+            // raw_lines,
             lines,
         }
     }
@@ -125,8 +125,8 @@ impl<'repo, 'syntax> BlobPager<'repo, 'syntax> {
         repo: &'repo Repository,
         object: Object<'repo>,
         name: String,
-        syntax_set: &'syntax SyntaxSet,
-        theme: &'syntax highlighting::Theme,
+        syntax_set: &SyntaxSet,
+        theme: &highlighting::Theme,
     ) -> Result<Self, GitBrowserError> {
         match object.into_blob() {
             Ok(blob) => {
@@ -141,7 +141,7 @@ impl<'repo, 'syntax> BlobPager<'repo, 'syntax> {
     }
 }
 
-impl<'repo, 'syntax> Drawable<'repo> for BlobPager<'repo, 'syntax> {
+impl<'repo> Drawable<'repo> for BlobPager<'repo> {
     fn draw(&self, f: &mut Frame, area: Rect, content_block_ext: Block) -> Rect {
         let content_block = content_block_ext.style(self.background_style);
 
@@ -199,7 +199,7 @@ impl<'repo, 'syntax> Drawable<'repo> for BlobPager<'repo, 'syntax> {
     }
 }
 
-impl<'repo, 'syntax> Navigable<'repo> for BlobPager<'repo, 'syntax> {
+impl<'repo> Navigable<'repo> for BlobPager<'repo> {
     fn home(&mut self, _page_size: u16) {
         self.top = 0;
     }

--- a/src/app/blob_pager.rs
+++ b/src/app/blob_pager.rs
@@ -119,10 +119,7 @@ impl<'repo> Drawable<'repo> for BlobPager<'repo> {
             vec![]
         };
 
-        let mut highlighter = match syntax {
-            Some(syntax) => Some(HighlightLines::new(syntax, theme)),
-            _ => None,
-        };
+        let mut highlighter = syntax.map(|s| HighlightLines::new(s, theme));
 
         let lines: Vec<Line> = self.lines[self.top..bottom]
             .iter()

--- a/src/app/blob_pager.rs
+++ b/src/app/blob_pager.rs
@@ -252,4 +252,7 @@ impl<'repo> Navigable<'repo> for BlobPager<'repo> {
     fn selected_item(&self) -> String {
         "".to_string()
     }
+
+    fn next_tick(&mut self) {
+    }
 }

--- a/src/app/navigation.rs
+++ b/src/app/navigation.rs
@@ -14,6 +14,7 @@ pub enum NavigationAction {
     PreviousSelection,
     ExternalEditor,
     Exit,
+    Tick,
     Invalid,
 }
 
@@ -68,6 +69,7 @@ impl From<&NavigationAction> for ActionInfo {
             NavigationAction::ExternalEditor => ("C-e", "Launch external pager for blob"),
             // We never want to see this but have to define it
             NavigationAction::Invalid => ("invalid", "invalid"),
+            NavigationAction::Tick => ("invalid", "invalid"),
         };
         ActionInfo {
             key: key.to_string(),

--- a/src/app/refs_page.rs
+++ b/src/app/refs_page.rs
@@ -9,6 +9,7 @@ use ratatui::{
 };
 
 use crate::app::pagination::pagination;
+use crate::errors::GitBrowserError;
 use crate::traits::{Drawable, Navigable};
 
 pub struct RefsPage<'repo> {
@@ -145,5 +146,7 @@ impl<'repo> Navigable<'repo> for RefsPage<'repo> {
         }
     }
 
-    fn next_tick(&mut self) {}
+    fn next_tick(&mut self, _block: bool) -> Result<(), GitBrowserError> {
+        Ok(())
+    }
 }

--- a/src/app/refs_page.rs
+++ b/src/app/refs_page.rs
@@ -144,4 +144,6 @@ impl<'repo> Navigable<'repo> for RefsPage<'repo> {
             items[self.selected_index].to_string()
         }
     }
+
+    fn next_tick(&mut self) {}
 }

--- a/src/app/tree_page.rs
+++ b/src/app/tree_page.rs
@@ -8,6 +8,7 @@ use ratatui::{
 };
 
 use crate::app::pagination::pagination;
+use crate::errors::GitBrowserError;
 use crate::traits::{Display, Drawable, Navigable};
 
 pub struct TreePage<'repo> {
@@ -168,5 +169,7 @@ impl<'repo> Navigable<'repo> for TreePage<'repo> {
         }
     }
 
-    fn next_tick(&mut self) {}
+    fn next_tick(&mut self, _block: bool) -> Result<(), GitBrowserError> {
+        Ok(())
+    }
 }

--- a/src/app/tree_page.rs
+++ b/src/app/tree_page.rs
@@ -167,4 +167,6 @@ impl<'repo> Navigable<'repo> for TreePage<'repo> {
             }
         }
     }
+
+    fn next_tick(&mut self) {}
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,8 +15,6 @@ use crate::{
 
 use color_eyre::Result;
 
-use two_face::re_exports::syntect;
-
 use clap::Parser;
 use git2::{Object, Repository};
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,6 +15,8 @@ use crate::{
 
 use color_eyre::Result;
 
+use two_face::re_exports::syntect;
+
 use clap::Parser;
 use git2::{Object, Repository};
 
@@ -64,8 +66,14 @@ fn main() -> Result<()> {
         }
     };
 
+    let syntax_set = two_face::syntax::extra_newlines();
+    let theme_set = two_face::theme::extra();
+    let theme = theme_set
+        .get(two_face::theme::EmbeddedThemeName::Nord)
+        .clone();
+
     let mut terminal = tui::init()?;
-    let mut app = App::new(&repo, commit, pager);
+    let mut app = App::new(&repo, commit, pager, &syntax_set, &theme);
     run_app(&mut terminal, &mut app)?;
     tui::restore()?;
     Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,8 +16,6 @@ use crate::{
 
 use color_eyre::Result;
 
-use two_face::re_exports::syntect;
-
 use clap::Parser;
 use git2::{Object, Repository};
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 use std::env;
+use std::time::Duration;
 
 use crossterm::event::{self, Event, KeyCode, KeyEventKind, KeyModifiers};
 use ratatui::{backend::Backend, Terminal};
@@ -84,6 +85,17 @@ fn run_app<B: Backend>(terminal: &mut Terminal<B>, app: &mut App) -> Result<bool
             terminal.clear()?;
         }
         terminal.draw(|f| ui(f, app))?;
+
+        if !event::poll(Duration::from_millis(50))? {
+            redraw = match app.navigate(&NavigationAction::Tick) {
+                Ok(redraw) => redraw.0,
+                Err(error) => {
+                    app.error(error);
+                    true
+                }
+            };
+            continue;
+        }
 
         let read_event = event::read()?;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,6 +16,8 @@ use crate::{
 
 use color_eyre::Result;
 
+use two_face::re_exports::syntect;
+
 use clap::Parser;
 use git2::{Object, Repository};
 

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1,3 +1,5 @@
+use color_eyre::Result;
+
 use git2::{Object, ObjectType, Repository, TreeEntry};
 
 use ratatui::{
@@ -7,6 +9,8 @@ use ratatui::{
     widgets::Block,
     Frame,
 };
+
+use crate::errors::GitBrowserError;
 
 pub trait Display {
     fn display_kind(&self, repo: &Repository) -> Option<(String, Style)>;
@@ -23,7 +27,7 @@ pub trait Navigable<'repo> {
     fn previous_selection(&mut self);
     fn select(&self) -> Option<(Object<'repo>, String)>;
     fn selected_item(&self) -> String;
-    fn next_tick(&mut self);
+    fn next_tick(&mut self, block: bool) -> Result<(), GitBrowserError>;
 }
 
 pub trait Drawable<'repo> {

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -23,6 +23,7 @@ pub trait Navigable<'repo> {
     fn previous_selection(&mut self);
     fn select(&self) -> Option<(Object<'repo>, String)>;
     fn selected_item(&self) -> String;
+    fn next_tick(&mut self);
 }
 
 pub trait Drawable<'repo> {


### PR DESCRIPTION
Naive syntax highlighting.

Due to the original pager design, so highlighting runs on every draw. As a result, it has two main issues:
1. ~A lot slower than it needs to be~
2. ~Syntax highlighting can break (show errors) when scrolling down a buffer~

This now progressively processes the input for highlighting, but on a large file, if `End` is pushed, then it blocks to consume the whole input. But now my CPU usage is quite high while idle (5%), as it no longer blocks on user input and "ticks" every 50ms